### PR TITLE
Transparently handle paginated viewsets

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,0 +1,15 @@
+##########
+Change Log
+##########
+
+All notable changes to this project are documented in this file.
+
+
+==========
+Unreleased
+==========
+
+Changed
+-------
+- Transparently support paginated viewsets
+

--- a/rest_framework_reactive/observer.py
+++ b/rest_framework_reactive/observer.py
@@ -124,9 +124,13 @@ class QueryObserver(object):
 
                     if not isinstance(results, list):
                         if isinstance(results, dict):
-                            self.primary_key = 'id'
-                            results['id'] = 1
-                            results = [collections.OrderedDict(results)]
+                            if 'results' in results and isinstance(results['results'], list):
+                                # Support paginated results.
+                                results = results['results']
+                            else:
+                                self.primary_key = 'id'
+                                results['id'] = 1
+                                results = [collections.OrderedDict(results)]
                         else:
                             raise ValueError("Observable views must return a dictionary or a list of dictionaries!")
                 else:

--- a/rest_framework_reactive/tests/views.py
+++ b/rest_framework_reactive/tests/views.py
@@ -2,6 +2,7 @@
 The views defined here are only used during testing.
 """
 from rest_framework import mixins, viewsets
+from rest_framework.pagination import LimitOffsetPagination
 
 from . import models, serializers
 
@@ -22,3 +23,12 @@ class ExampleSubItemViewSet(mixins.RetrieveModelMixin,
     queryset = models.ExampleSubItem.objects.all()
     serializer_class = serializers.ExampleSubItemSerializer
     filter_fields = ('parent__enabled', 'enabled')
+
+
+class PaginatedViewSet(mixins.RetrieveModelMixin,
+                       mixins.ListModelMixin,
+                       viewsets.GenericViewSet):
+
+    queryset = models.ExampleItem.objects.all()
+    serializer_class = serializers.ExampleItemSerializer
+    pagination_class = LimitOffsetPagination

--- a/tests/.env
+++ b/tests/.env
@@ -1,0 +1,9 @@
+# Default values of environment variables for Docker Compose
+#
+# NOTE: Values present in the environment at runtime will always override
+# values inside this file. Similarly, values passed via command-line arguments
+# take precedence as well.
+#
+# For more information, see: https://docs.docker.com/compose/env-file/
+# 
+COMPOSE_PROJECT_NAME=drfreactive

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,15 @@
+#
+# Development configuration of dependent services for Docker Compose.
+#
+postgresql:
+    image: postgres:9.4
+    environment:
+        POSTGRES_USER: drfr
+        POSTGRES_DB: drfr
+    ports:
+        - "55435:5432"
+redis:
+    image: redis
+    ports:
+        - "56380:6379"
+

--- a/tests/manage.py
+++ b/tests/manage.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+import os
+import sys
+
+PROJECT_ROOT = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
+sys.path.insert(0, PROJECT_ROOT)
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
+
+    # if len(sys.argv) > 1 and sys.argv[1] == 'runserver':
+    #     raise ValueError('This Django project is not intended for running a server.')
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,105 @@
+"""
+Django settings for running tests for django-rest-framework-reactive package.
+
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+
+PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
+
+SECRET_KEY = 'secret'
+
+DEBUG = True
+
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+)
+
+# Apps from this project
+PROJECT_APPS = (
+    'rest_framework_reactive',
+)
+
+INSTALLED_APPS = (
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.staticfiles',
+
+    'rest_framework',
+    'ws4redis',
+    'guardian',
+) + PROJECT_APPS
+
+ROOT_URLCONF = 'tests.urls'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+            ],
+        },
+    },
+]
+
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
+)
+
+ANONYMOUS_USER_NAME = 'public'
+
+# Get the current Tox testing environment
+# NOTE: This is useful for concurrently running tests with separate environments
+toxenv = os.environ.get('TOXENV', '')
+
+# Check if PostgreSQL settings are set via environment variables
+pgname = os.environ.get('DRFR_POSTGRESQL_NAME', 'drfr')
+pguser = os.environ.get('DRFR_POSTGRESQL_USER', 'drfr')
+pghost = os.environ.get('DRFR_POSTGRESQL_HOST', 'localhost')
+pgport = int(os.environ.get('DRFR_POSTGRESQL_PORT', 55435))
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': pgname,
+        'USER': pguser,
+        'HOST': pghost,
+        'PORT': pgport,
+        'TEST': {
+            'NAME': 'drfr_test' + toxenv
+        }
+    }
+}
+
+STATIC_URL = '/static/'
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.SessionAuthentication',
+    ),
+    'DEFAULT_FILTER_BACKENDS': (
+        'rest_framework_filters.backends.DjangoFilterBackend',
+        'rest_framework.filters.OrderingFilter',
+    ),
+}
+
+REDIS_CONNECTION = {
+    'host': 'localhost',
+    'port': int(os.environ.get('DRFR_REDIS_PORT', 56380)),
+    'db': 0,
+}
+
+WS4REDIS_CONNECTION = REDIS_CONNECTION
+
+WS4REDIS_PREFIX = 'ws'
+
+WS4REDIS_SUBSCRIBER = 'rest_framework_reactive.websockets.QueryObserverSubscriber'

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from django.conf.urls import include, url
+
+
+urlpatterns = [
+    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+]


### PR DESCRIPTION
Adds a test runner project under `tests/` and an update to transparently handle paginated viewsets (the pagination metadata is currently ignored).