### PR TITLE
Performance improvements

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,11 +14,13 @@ Added
 * Logging of slow observers and automatic stopping of very slow
   observers (both are configurable)
 * Status endpoint to track server status
+* Configurable update batch delay
 
 Fixed
 -----
 * ``META`` passthrough in requests
 * Correct passthrough of ``request.method``
+* Improved observer concurrency
 
 
 =================

--- a/rest_framework_reactive/connection.py
+++ b/rest_framework_reactive/connection.py
@@ -36,6 +36,10 @@ def get_queryobserver_settings():
         'errors': {
             'max_processing_time': 20.0,
         },
+        # Update batch delay (in seconds). If a new update comes earlier than the
+        # delay value, queue processing will be delayed so multiple updates can be
+        # batched. A higher value introduces more latency.
+        'update_batch_delay': 5,
     }
     defaults.update(getattr(settings, 'DJANGO_REST_FRAMEWORK_REACTIVE', {}))
     return defaults

--- a/rest_framework_reactive/pool.py
+++ b/rest_framework_reactive/pool.py
@@ -113,6 +113,7 @@ class QueryObserverPool(object):
         self._subscribers = {}
         self._queue = set()
         self._pending_process = False
+        self._evaluations = 0
         self.query_interceptor = QueryInterceptor(self)
 
     @property
@@ -127,6 +128,7 @@ class QueryObserverPool(object):
             'tables': len(self._tables),
             'subscribers': len(self._subscribers),
             'queue': len(self._queue),
+            'evaluations': self._evaluations,
         }
 
     @serializable
@@ -190,6 +192,7 @@ class QueryObserverPool(object):
 
         query_observer.subscribe(subscriber)
         self._subscribers.setdefault(subscriber, set()).add(query_observer)
+        self._evaluations += 1
         return query_observer
 
     @serializable
@@ -284,6 +287,7 @@ class QueryObserverPool(object):
         try:
             for observer in queue:
                 try:
+                    self._evaluations += 1
                     observer.evaluate(return_full=False)
                 except exceptions.ObserverStopped:
                     pass


### PR DESCRIPTION
* [x] Track number of observer evaluations and report via the status endpoint (can be used to show how many observers are executing per second in a monitoring system).
* [x] Add configurable update batch delay, which can be used to set a trade off between latency and resource usage (defaults to 5 seconds, a higher value means more latency but less resource usage). Granularity is per-observer.
* [x] Improve observer I/O concurrency by properly spawning each evaluator in its own greenlet.