### PR TITLE
Rewrite query interceptor with TLS

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -4,6 +4,15 @@ Change Log
 
 All notable changes to this project are documented in this file.
 
+==========
+Unreleased
+==========
+
+Fixed
+-----
+* Rewrite query interceptor to properly handle multiple threads
+
+
 ================
 3.0.4 2018-06-08
 ================

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -4,9 +4,9 @@ Change Log
 
 All notable changes to this project are documented in this file.
 
-==========
-Unreleased
-==========
+================
+3.0.5 2018-06-12
+================
 
 Fixed
 -----

--- a/rest_framework_reactive/__about__.py
+++ b/rest_framework_reactive/__about__.py
@@ -8,7 +8,7 @@ __url__ = 'https://github.com/genialis/django-rest-framework-reactive'
 
 # Semantic versioning is used. For more information see:
 # https://packaging.python.org/en/latest/distributing/#semantic-versioning-preferred
-__version__ = '3.0.4'
+__version__ = '3.0.5'
 
 __author__ = 'Genialis d.o.o.'
 __email__ = 'dev-team@genialis.com'

--- a/rest_framework_reactive/interceptor.py
+++ b/rest_framework_reactive/interceptor.py
@@ -3,51 +3,28 @@ import threading
 
 from django.db.models.sql import compiler
 
-# Global interceptor lock.
-INTERCEPTOR_LOCK = threading.Lock()
+# Thread-local storage for intercepted tables.
+INTERCEPTOR_TLS = threading.local()
+
+_original_as_sql = compiler.SQLCompiler.as_sql
+def intercept_as_sql(compiler, *args, **kwargs):
+    result = _original_as_sql(compiler, *args, **kwargs)
+    tables = getattr(INTERCEPTOR_TLS, 'tables', None)
+    if tables is None:
+        return result
+
+    tables.update([table for table in compiler.query.tables if table != table.upper()])
+    return result
+
+# Monkey patch the SQLCompiler class to get all referenced tables in a code block.
+compiler.SQLCompiler.as_sql = intercept_as_sql
 
 
 class QueryInterceptor(object):
     """Django ORM query interceptor."""
 
     def __init__(self):
-        self.intercepting_queries = 0
         self.tables = set()
-        self.thread = threading.current_thread()
-
-    def _patch(self):
-        """Monkey patch the SQLCompiler class to get all the referenced tables in a code block."""
-        assert threading.current_thread() == self.thread
-
-        self.intercepting_queries += 1
-        if self.intercepting_queries > 1:
-            return
-
-        with INTERCEPTOR_LOCK:
-            self._original_as_sql = compiler.SQLCompiler.as_sql
-
-            def as_sql(compiler, *args, **kwargs):
-                result = self._original_as_sql(compiler, *args, **kwargs)
-                if threading.current_thread() != self.thread:
-                    return result
-
-                self.tables.update([table for table in compiler.query.tables if table != table.upper()])
-                return result
-
-            compiler.SQLCompiler.as_sql = as_sql
-
-    def _unpatch(self):
-        """Restore SQLCompiler monkey patches."""
-        assert threading.current_thread() == self.thread
-
-        self.intercepting_queries -= 1
-        assert self.intercepting_queries >= 0
-
-        if self.intercepting_queries:
-            return
-
-        with INTERCEPTOR_LOCK:
-            compiler.SQLCompiler.as_sql = self._original_as_sql
 
     @contextlib.contextmanager
     def intercept(self, tables):
@@ -55,12 +32,13 @@ class QueryInterceptor(object):
 
         :param tables: Output tables set
         """
-        self._patch()
+        global INTERCEPTOR_TLS
 
+        INTERCEPTOR_TLS.tables = self.tables
         try:
             # Run the code block.
             yield
         finally:
-            self._unpatch()
             # Collect intercepted tables.
-            tables.update(self.tables)
+            tables.update(INTERCEPTOR_TLS.tables)
+            del INTERCEPTOR_TLS.tables


### PR DESCRIPTION
Only patch the SQL compiler once and store results in thread-local storage. This should fix issues with patching from multiple threads producing issues.