### PR TITLE
Use a bounded cache with LRU eviction policy

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -11,6 +11,7 @@ Unreleased
 Fixed
 -----
 * Do not mutate received update message in client consumer
+* Use a bounded cache with LRU eviction policy for executors
 
 
 ================

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -4,9 +4,9 @@ Change Log
 
 All notable changes to this project are documented in this file.
 
-==========
-Unreleased
-==========
+================
+3.0.8 2018-07-10
+================
 
 Fixed
 -----

--- a/rest_framework_reactive/__about__.py
+++ b/rest_framework_reactive/__about__.py
@@ -8,7 +8,7 @@ __url__ = 'https://github.com/genialis/django-rest-framework-reactive'
 
 # Semantic versioning is used. For more information see:
 # https://packaging.python.org/en/latest/distributing/#semantic-versioning-preferred
-__version__ = '3.0.7'
+__version__ = '3.0.8'
 
 __author__ = 'Genialis d.o.o.'
 __email__ = 'dev-team@genialis.com'


### PR DESCRIPTION
Previously the executor cache could grow indefinitely causing memory leaks. This bounds the number of cached executors per consumer instance and uses a LRU eviction policy for expiring old entries.