### PR TITLE
Update linters arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,5 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-py36 = true
+target_version = ['py36', 'py37']
 skip-string-normalization = true

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setuptools.setup(
             'django-guardian>=1.5',
             'django-priority-batch~=2.0',
             'channels-redis~=2.4',
-            'pylint~=2.3.1',
             'pytest~=4.4.1',
             'pytest-django~=3.4.8',
             'pytest-asyncio~=0.10.0',

--- a/src/rest_framework_reactive/__init__.py
+++ b/src/rest_framework_reactive/__init__.py
@@ -1,3 +1,1 @@
-default_app_config = (
-    'rest_framework_reactive.apps.BaseConfig'
-)  # pylint: disable=invalid-name
+default_app_config = 'rest_framework_reactive.apps.BaseConfig'

--- a/src/rest_framework_reactive/apps.py
+++ b/src/rest_framework_reactive/apps.py
@@ -10,4 +10,4 @@ class BaseConfig(AppConfig):
     def ready(self):
         """Perform application initialization."""
         # Connect all signals.
-        from . import signals  # pylint: disable=unused-variable
+        from . import signals

--- a/src/rest_framework_reactive/observer.py
+++ b/src/rest_framework_reactive/observer.py
@@ -17,7 +17,7 @@ from .connection import get_queryobserver_settings
 from .protocol import *
 
 # Logger.
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 # Observable method options attribute name prefix.
 OBSERVABLE_OPTIONS_PREFIX = 'observable_'

--- a/src/rest_framework_reactive/signals.py
+++ b/src/rest_framework_reactive/signals.py
@@ -12,7 +12,7 @@ from .models import Observer
 from .protocol import *
 
 # Logger.
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 # Global 'in migrations' flag to skip certain operations during migrations.
 IN_MIGRATIONS = False


### PR DESCRIPTION
- Argument --py36 is deprecated, using target-version instead.
- Include Python3.7 formatting support in linters.